### PR TITLE
Fix Python syntax error

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -33,7 +33,7 @@ class ActorCritic(nn.Module):
         x = F.relu(self.conv2(x))
         x = F.relu(self.conv3(x))
         x = F.relu(self.conv4(x))
-        hx, cx= self.lstm(x.size(0), -1), (hx, cx))
+        hx, cx= self.lstm(x.size(0), -1), (hx, cx)
         return self.actor_linear(hx), self.critic_linear(hx), hx, cx
 
 


### PR DESCRIPTION
See #1 

[flake8](http://flake8.pycqa.org) testing of https://github.com/vietnguyen91/Super-mario-bros-A3C-pytorch on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./src/model.py:1:1: E902 TokenError: EOF in multi-line statement
"""
^
./src/model.py:36:51: E999 SyntaxError: invalid syntax
        hx, cx= self.lstm(x.size(0), -1), (hx, cx))
                                                  ^
1     E902 TokenError: EOF in multi-line statement
1     E999 SyntaxError: invalid syntax
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree